### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "@types/pg": "^8.20.0",
     "prisma": "^7.8.0",
     "tsx": "^4.22.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
-    "@types/node": "^24.9.2",
+    "@types/node": "^25.9.3",
     "@types/pg": "^8.20.0",
     "prisma": "^7.8.0",
     "tsx": "^4.22.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "graphql": "^16.14.2",
     "graphql-scalars": "^1.25.0",
     "graphql-yoga": "5.21.2",
-    "pg": "^8.21.0",
+    "pg": "^8.22.0",
     "prisma-case-format": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "express-rate-limit": "^8.5.2",
     "graphql": "^16.14.2",
     "graphql-scalars": "^1.25.0",
-    "graphql-yoga": "5.21.1",
+    "graphql-yoga": "5.21.2",
     "pg": "^8.21.0",
     "prisma-case-format": "^2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
-    "graphql": "^16.14.1",
+    "graphql": "^16.14.2",
     "graphql-scalars": "^1.25.0",
     "graphql-yoga": "5.21.1",
     "pg": "^8.21.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@as-integrations/express5": "^1.1.2",
     "@gqloom/core": "^0.16.1",
     "@gqloom/prisma": "^0.16.0",
-    "@graphql-yoga/render-graphiql": "^5.21.0",
+    "@graphql-yoga/render-graphiql": "^5.21.2",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "dotenv": "^17.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,10 +2090,10 @@ graphql-scalars@^1.25.0:
   dependencies:
     tslib "^2.5.0"
 
-graphql-yoga@5.21.1:
-  version "5.21.1"
-  resolved "https://registry.yarnpkg.com/graphql-yoga/-/graphql-yoga-5.21.1.tgz#a71b1a2855230b51e3ef88bd6daf9a908a013f03"
-  integrity sha512-NlACyYkLh7MBp3Mb2pTB2LG//5MyuHgSs7tWwkgCTuX98Aler7Djeb06ruuLBBa7gaT2cHpv7LwKayruLnXD0g==
+graphql-yoga@5.21.2:
+  version "5.21.2"
+  resolved "https://registry.yarnpkg.com/graphql-yoga/-/graphql-yoga-5.21.2.tgz#93c8c15c67b7b515d3c6d70b70b9261984fe97fe"
+  integrity sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw==
   dependencies:
     "@envelop/core" "^5.5.1"
     "@envelop/instrumentation" "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,10 +2115,10 @@ graphql-yoga@5.21.1:
     lru-cache "^10.0.0"
     tslib "^2.8.1"
 
-graphql@^16.14.1:
-  version "16.14.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.1.tgz#e692888b5103480a71e48cd9c3ed1dd8b0c5af7f"
-  integrity sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==
+graphql@^16.14.2:
+  version "16.14.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.2.tgz#83faf25869e3df727cc855161db5da85b0e5b2c0"
+  integrity sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==
 
 has-flag@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,12 +939,12 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@*", "@types/node@^25.9.3":
-  version "25.9.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.3.tgz#11dfe7a33e68fa5c560f0aa76cc5595621ef26b9"
-  integrity sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==
+"@types/node@*", "@types/node@^26.0.0":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.0.0.tgz#d4aece9e9412e9f2008d59bc2d74f5279316b665"
+  integrity sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==
   dependencies:
-    undici-types ">=7.24.0 <7.24.7"
+    undici-types "~8.3.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -3684,10 +3684,10 @@ typescript@^6.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
-"undici-types@>=7.24.0 <7.24.7":
-  version "7.24.6"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
-  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
 unique-string@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
   dependencies:
     tslib "^2.8.1"
 
-"@graphql-yoga/render-graphiql@^5.21.0":
-  version "5.21.1"
-  resolved "https://registry.yarnpkg.com/@graphql-yoga/render-graphiql/-/render-graphiql-5.21.1.tgz#3060cd51775568ec2794ea7ef6f36d178c0d9da1"
-  integrity sha512-9Ksrp9mgzN84C4AB6F2YFNFw+LEliN/yxfWu0ugAHPYjYwduUFTbmdq0lXQZ9FmuuNPe2ROn0UZ2JMHqLVMtfg==
+"@graphql-yoga/render-graphiql@^5.21.2":
+  version "5.21.2"
+  resolved "https://registry.yarnpkg.com/@graphql-yoga/render-graphiql/-/render-graphiql-5.21.2.tgz#4f62a28f13b211455a1c29ff00e7e0df1bf1f66c"
+  integrity sha512-m0Tw1lY1sOVxmnHK0epZF6tvmG3AqRRxoiCVwWTXqQIo5O2Za2dM8FJ5MqcGekEtN2hKU16OTHYS2OlNG1B2Aw==
 
 "@graphql-yoga/subscription@^5.0.5":
   version "5.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2883,10 +2883,10 @@ pg-cloudflare@^1.4.0:
   resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz#4b4c20e6d8ae531d400730f4804571a8d62f1497"
   integrity sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==
 
-pg-connection-string@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.13.0.tgz#8678113465a5af3cc977dcb51eadc847b27aa2de"
-  integrity sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==
+pg-connection-string@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.14.0.tgz#abc26ee4f37c56c0f3ae0fcf0b0653cc4e1c0fd9"
+  integrity sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -2898,10 +2898,10 @@ pg-pool@^3.14.0:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.14.0.tgz#f35ae4eb846780cad71af24099b3edfa9781ad90"
   integrity sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==
 
-pg-protocol@*, pg-protocol@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.14.0.tgz#c1f045b74274b007078c687147141f785f59b8de"
-  integrity sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==
+pg-protocol@*, pg-protocol@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.15.0.tgz#758f6c0679cc0bbf4938603b7597703f333180c0"
+  integrity sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==
 
 pg-types@2.2.0, pg-types@^2.2.0:
   version "2.2.0"
@@ -2914,14 +2914,14 @@ pg-types@2.2.0, pg-types@^2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.16.3, pg@^8.21.0:
-  version "8.21.0"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-8.21.0.tgz#d7fa2118d960cec5cc7d2b24525f9850dd5932b0"
-  integrity sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==
+pg@^8.16.3, pg@^8.22.0:
+  version "8.22.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.22.0.tgz#55ca3975026180c6dced6eec3a20a844c2dc9237"
+  integrity sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==
   dependencies:
-    pg-connection-string "^2.13.0"
+    pg-connection-string "^2.14.0"
     pg-pool "^3.14.0"
-    pg-protocol "^1.14.0"
+    pg-protocol "^1.15.0"
     pg-types "2.2.0"
     pgpass "1.0.5"
   optionalDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,19 +939,12 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@*":
-  version "25.9.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.2.tgz#fc8958e757994b71fee516f9634bdb03d1b19e9f"
-  integrity sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==
+"@types/node@*", "@types/node@^25.9.3":
+  version "25.9.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.3.tgz#11dfe7a33e68fa5c560f0aa76cc5595621ef26b9"
+  integrity sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
-
-"@types/node@^24.9.2":
-  version "24.13.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.2.tgz#3b9b280a7055128359f125eb1067d9a190f39854"
-  integrity sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==
-  dependencies:
-    undici-types "~7.18.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -3695,11 +3688,6 @@ typescript@^6.0.3:
   version "7.24.6"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
-
-undici-types@~7.18.0:
-  version "7.18.2"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
-  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refreshes core GraphQL and Postgres dependencies and bumps Node type definitions to keep the stack current and compatible. No application code changes; only dependency updates.

- **Dependencies**
  - `@types/node` -> `^26.0.0` (major types update)
  - `graphql` -> `^16.14.2` (patch)
  - `graphql-yoga` -> `5.21.2` (patch)
  - `@graphql-yoga/render-graphiql` -> `^5.21.2` (patch)
  - `pg` -> `^8.22.0` (minor)

<sup>Written for commit 5ea7c30f6c1ed83ef064e8e764686ad2b3f8bb12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/F1-GraphQL-API/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates several npm dependencies to their latest patch/minor versions: `graphql` (16.14.1→16.14.2), `graphql-yoga` (5.21.1→5.21.2), `@graphql-yoga/render-graphiql` (5.21.0→5.21.2), `pg` (8.21.0→8.22.0), and `@types/node` (24.9.2→26.0.0). The `yarn.lock` is regenerated accordingly.

- **`@types/node` major version jump** (v24→v26): The project's `engines` field still pins Node.js to `24.x`, so the TypeScript type checker will now validate code against the Node 26 API surface while the runtime stays on Node 24 — any newly-used Node 26 API would compile cleanly but fail at runtime.
- All other bumps (`graphql`, `graphql-yoga`, `pg`, `render-graphiql`) are patch or minor increments with no API breakage expected.

<h3>Confidence Score: 4/5</h3>

Safe to merge if the @types/node version is intentionally bumped ahead of a Node 24→26 runtime upgrade; risky if the runtime stays at Node 24 and newer Node 26 APIs get used in source code.

The @types/node jump from v24 to v26 creates a gap between the TypeScript type checker and the declared runtime. If any Node 26 API surfaces in the codebase, TypeScript will accept it while Node 24 will throw at runtime. All other dependency bumps are patch or minor and carry low risk.

package.json — specifically the @types/node version vs the engines.node constraint.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Bumps several dependencies (graphql, graphql-yoga, pg, @types/node, render-graphiql); introduces a mismatch between @types/node@^26.0.0 and engines.node=24.x which could allow Node 26 APIs to slip past the type checker undetected. |
| yarn.lock | Lockfile updated to reflect the new resolved versions for @types/node (26.0.0), graphql (16.14.2), graphql-yoga (5.21.2), pg (8.22.0), and their transitive sub-dependencies; no anomalies in resolved URLs or checksums. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json engines: node 24.x] -->|runtime target| B[Node.js 24 runtime]
    C["@types/node ^26.0.0"] -->|type-checks against| D[Node.js 26 API surface]
    D -->|APIs absent in| B
    B -->|runtime failure| E["❌ Runtime error if Node 26 API used"]
    F["graphql 16.14.1 → 16.14.2\ngraphql-yoga 5.21.1 → 5.21.2\npg 8.21.0 → 8.22.0\nrender-graphiql 5.21.0 → 5.21.2"] -->|patch/minor bumps| G["✅ No breaking changes expected"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[package.json engines: node 24.x] -->|runtime target| B[Node.js 24 runtime]
    C["@types/node ^26.0.0"] -->|type-checks against| D[Node.js 26 API surface]
    D -->|APIs absent in| B
    B -->|runtime failure| E["❌ Runtime error if Node 26 API used"]
    F["graphql 16.14.1 → 16.14.2\ngraphql-yoga 5.21.1 → 5.21.2\npg 8.21.0 → 8.22.0\nrender-graphiql 5.21.0 → 5.21.2"] -->|patch/minor bumps| G["✅ No breaking changes expected"]
```

</a>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22francostino%2Ff1-graphql-api%22%20on%20the%20existing%20branch%20%22develop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22develop%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackage.json%3A39%0AThe%20%60engines%60%20field%20declares%20%60%22node%22%3A%20%2224.x%22%60%2C%20but%20%60%40types%2Fnode%60%20has%20been%20bumped%20to%20%60%5E26.0.0%60.%20These%20two%20major%20versions%20have%20different%20API%20surfaces%2C%20so%20TypeScript%20will%20now%20type-check%20against%20Node%2026%20globals%20and%20built-ins.%20Any%20Node%2026%20API%20used%20in%20source%20code%20will%20pass%20compilation%20but%20fail%20at%20runtime%20on%20a%20Node%2024%20host%20%E2%80%94%20with%20no%20type-level%20warning%20to%20catch%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22%40types%2Fnode%22%3A%20%22%5E24.0.0%22%2C%0A%60%60%60%0A%0A&repo=francostino%2Ff1-graphql-api&tid=70573&ts=1781983968&sig=ad5f365a888b3cdf1bff5c9b36e1fc796a6a5fe4d1864e1ced5799eb9f1e2e25&pr=207&platform=github&fid=98d90678-01cf-426a-b5fe-04ca65bbd332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #205 from FrancoStino..."](https://github.com/francostino/f1-graphql-api/commit/5ea7c30f6c1ed83ef064e8e764686ad2b3f8bb12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38831643)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->